### PR TITLE
Fix bot docs according to latest Windows library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ As a reminder the default search depth in the RPA.Windows is **8** (which applie
 see [library documentation](https://robocorp.com/docs/libraries/rpa-framework/rpa-windowss) for more information.
 - The second number indicates the **index of the element on its current level** (number 1 indicating the first element) on the element tree. 
 **This number is used as an value when creating a path for the element**. The root element index (in this case WindowControl of the Calculator application) 
-**is not** part of the element path index. Indexing starts from the depth level 2.
+**is not** part of the element path index. Indexing starts from the depth level 1. (as 0 is the singular root level)
 
 ### How value for `path:` locator is calculated ?
 
 In my Calculator Robot all elements of interest are contained within the element which I have assigned to variable `${path_to_mainview}`.
 
-To get element path for the `${path_to_mainview}` I can see from image that it is locator under the second index (under the parent window) "2-2" and then 
-under the third index of that structure "3-3" and finally under the second index of that structure "4-2". This gives the element path value of `2|3|2`. 
+To get element path for the `${path_to_mainview}` I can see from image that it is locator under the second index (under the parent window) "1-2" and then 
+under the third index of that structure "2-3" and finally under the second index of that structure "3-2". This gives the element path value of `2|3|2`. 
 The "calculation path" is indicated by white arrows on the left side of the element tree (shown only on how to get to this "main view").
 
 > pipe character `|` is used as separation character between indexing for different levels of elements

--- a/conda.yaml
+++ b/conda.yaml
@@ -12,4 +12,4 @@ dependencies:
   - pip=22.1.2                  # https://pip.pypa.io/en/stable/news/
   - pip:
       # Define pip packages here -> https://pypi.org/
-      - rpaframework==22.0.0    # https://rpaframework.org/releasenotes.html
+      - rpaframework==22.2.1    # https://rpaframework.org/releasenotes.html


### PR DESCRIPTION
The root indexing starts from 0 now given the depth. (children position remain 1-indexed)

This was fixed [here](https://github.com/robocorp/rpaframework/pull/855/files#diff-8436e48d903a1132805380547cd513f28976e1b06ced5d947f36feb69be8a516R212) because the depth level was reported wrongly in the `Print Tree` structure. (e.g. you'd set a max level of 8, but you'd see printed even levels of 9, as the root control isn't taken into account and considered 0-leveled, so the index **1** means the first child of the root)

### ToDo

- [x] Fix the screenshot to reflect the new README and functionality.